### PR TITLE
Make Option optional

### DIFF
--- a/Target/Interface/Integration.d.ts
+++ b/Target/Interface/Integration.d.ts
@@ -3,7 +3,7 @@
  *
  */
 export default interface Type {
-    (Option: Option): AstroIntegration;
+    (Option?: Option): AstroIntegration;
 }
 import type { AstroIntegration } from "astro";
 import type Option from "../Interface/Option.js";


### PR DESCRIPTION
This integration does not require options, but when using a `astro.config.ts` like this:

```ts
	integrations: [
		compress(),
	],
```

we see this:

```
Expected 1 arguments, but got 0.ts(2554)
Integration.d.ts(6, 6): An argument for 'Option' was not provided.
```