### PR TITLE
[feat]: Log only outDir path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/Source/Function/Integration.ts
+++ b/Source/Function/Integration.ts
@@ -2,6 +2,8 @@
  * @module Integration
  *
  */
+export let systemDir: string;
+
 export default ((...[_Option = {}]: Parameters<Type>) => {
 	Object.entries(_Option).forEach(([Key, Value]) =>
 		Object.defineProperty(_Option, Key, {
@@ -46,6 +48,12 @@ export default ((...[_Option = {}]: Parameters<Type>) => {
 	return {
 		name: "astro-compress",
 		hooks: {
+			"astro:config:done": async (options) => {
+				const { dir } = (await import("node:path")).parse(options.config.outDir.pathname);
+				// normalize slash and remove leading slash that always appears (conditional just in case)
+				systemDir = dir.replace(/\\/g, '/');
+				if (systemDir.startsWith("/")) { systemDir = systemDir.substring(1) }
+			},
 			"astro:build:done": async ({ dir }) => {
 				console.log(
 					`\n${(await import("kleur")).bgGreen(


### PR DESCRIPTION
Improvement to show only the path from the outDir

default outDir:
<img src="https://github.com/astro-community/AstroCompress/assets/61759797/32f93223-a306-42b6-94b7-29e979e7bd2d" width="60%"/>
custom outDir:
<img src="https://github.com/astro-community/AstroCompress/assets/61759797/707f46db-ecb9-4528-b23a-57245aa33d19" width="60%"/>

Btw, was those empty lines placed on purpose? I see there was some modifications to the code, and myself while editing added a a extra lines by mistake but I removed them, so I'm wondering.

If not, I can fix it in this PR.

Is it ok to leave the .gitignore? I use it locally but I commited it by mistake


